### PR TITLE
Fix GRPC client leak and some code refactorings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.18
+        go-version: ^1.17
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,9 +26,9 @@ jobs:
         fetch-depth: 0
 
     - name: Static Test
-      uses: dominikh/staticcheck-action@v1.1.0
+      uses: dominikh/staticcheck-action@v1.2.0
       with:
-        version: "2021.1.1"
+        version: "2022.1.2"
         install-go: false
 
     - name: Test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,6 +29,7 @@ jobs:
       uses: dominikh/staticcheck-action@v1.1.0
       with:
         version: "2021.1.1"
+        install-go: false
 
     - name: Test
       run: make test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.18
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ^1.17
 

--- a/etcd/client.go
+++ b/etcd/client.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 )
 
 type Config struct {
@@ -42,5 +43,11 @@ func WithAuth(username, password string) func(*Config) {
 	return func(cfg *Config) {
 		cfg.etcdConfig.Username = username
 		cfg.etcdConfig.Password = password
+	}
+}
+
+func WithLogger(logger *zap.Logger) func(*Config) {
+	return func(cfg *Config) {
+		cfg.etcdConfig.Logger = logger
 	}
 }

--- a/http/handlers/authenticate.go
+++ b/http/handlers/authenticate.go
@@ -6,17 +6,19 @@ import (
 	"time"
 
 	"github.com/srimaln91/etcd-adminer/etcd"
+	"github.com/srimaln91/etcd-adminer/http/request"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 func (jh *GenericHandler) Authenticate(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
-
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	_, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	
+	_, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/authenticate.go
+++ b/http/handlers/authenticate.go
@@ -12,7 +12,7 @@ import (
 
 func (jh *GenericHandler) Authenticate(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/authenticate.go
+++ b/http/handlers/authenticate.go
@@ -16,7 +16,7 @@ func (jh *GenericHandler) Authenticate(rw http.ResponseWriter, r *http.Request) 
 	endpointString := r.Header.Get("X-Endpoints")
 	endpoints := parseEndpoints(endpointString)
 
-	_, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -26,6 +26,8 @@ func (jh *GenericHandler) Authenticate(rw http.ResponseWriter, r *http.Request) 
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+
+	defer jh.closeEtcdClient(client)
 
 	response := struct {
 		Token    string    `json:"token"`

--- a/http/handlers/cluster_info.go
+++ b/http/handlers/cluster_info.go
@@ -32,6 +32,8 @@ func (jh *GenericHandler) ClusterInfo(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	members, err := client.Cluster.MemberList(r.Context())
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
@@ -57,6 +59,8 @@ func (jh *GenericHandler) ClusterInfo(rw http.ResponseWriter, r *http.Request) {
 		endpointStatus, err := client.Status(r.Context(), member.GetClientURLs()[0])
 		if err != nil {
 			jh.logger.Error(r.Context(), err.Error())
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
 		}
 
 		if member.GetID() == endpointStatus.Leader {

--- a/http/handlers/cluster_info.go
+++ b/http/handlers/cluster_info.go
@@ -17,7 +17,7 @@ const (
 )
 
 func (jh *GenericHandler) ClusterInfo(rw http.ResponseWriter, r *http.Request) {
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/cluster_info.go
+++ b/http/handlers/cluster_info.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/srimaln91/etcd-adminer/etcd"
+	"github.com/srimaln91/etcd-adminer/http/request"
 	"github.com/srimaln91/etcd-adminer/http/response"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
@@ -16,12 +17,13 @@ const (
 )
 
 func (jh *GenericHandler) ClusterInfo(rw http.ResponseWriter, r *http.Request) {
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/create_directory.go
+++ b/http/handlers/create_directory.go
@@ -12,7 +12,7 @@ import (
 
 func (jh *GenericHandler) CreateDirectory(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/create_directory.go
+++ b/http/handlers/create_directory.go
@@ -12,10 +12,11 @@ import (
 
 func (jh *GenericHandler) CreateDirectory(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
-
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	reqDataDecoded := request.CreateDirectoryRequest{}
 	decoder := json.NewDecoder(r.Body)
@@ -32,7 +33,7 @@ func (jh *GenericHandler) CreateDirectory(rw http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	keys, err := jh.getKeys(r.Context(), endpoints, user, pass)
+	keys, err := jh.getKeys(r.Context(), requestMeta.Endpoints, requestMeta.User, requestMeta.Pass)
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/delete_key.go
+++ b/http/handlers/delete_key.go
@@ -28,6 +28,8 @@ func (jh *GenericHandler) DeleteKey(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	reqDataDecoded := request.DeleteKeyRequest{}
 	decoder := json.NewDecoder(r.Body)
 

--- a/http/handlers/delete_key.go
+++ b/http/handlers/delete_key.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (jh *GenericHandler) DeleteKey(rw http.ResponseWriter, r *http.Request) {
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/delete_key.go
+++ b/http/handlers/delete_key.go
@@ -12,12 +12,13 @@ import (
 )
 
 func (jh *GenericHandler) DeleteKey(rw http.ResponseWriter, r *http.Request) {
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/get_key.go
+++ b/http/handlers/get_key.go
@@ -27,6 +27,8 @@ func (jh *GenericHandler) GetKey(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	queryParams := r.URL.Query()
 	requestedKey := queryParams.Get("key")
 

--- a/http/handlers/get_key.go
+++ b/http/handlers/get_key.go
@@ -5,18 +5,20 @@ import (
 	"net/http"
 
 	"github.com/srimaln91/etcd-adminer/etcd"
+	"github.com/srimaln91/etcd-adminer/http/request"
 	"github.com/srimaln91/etcd-adminer/http/response"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 func (jh *GenericHandler) GetKey(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/get_key.go
+++ b/http/handlers/get_key.go
@@ -12,7 +12,7 @@ import (
 
 func (jh *GenericHandler) GetKey(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/get_keys.go
+++ b/http/handlers/get_keys.go
@@ -6,17 +6,19 @@ import (
 	"strings"
 
 	"github.com/srimaln91/etcd-adminer/filetree"
+	"github.com/srimaln91/etcd-adminer/http/request"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 func (jh *GenericHandler) GetKeys(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	keys, err := jh.getKeys(r.Context(), endpoints, user, pass)
+	keys, err := jh.getKeys(r.Context(), requestMeta.Endpoints, requestMeta.User, requestMeta.Pass)
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/get_keys.go
+++ b/http/handlers/get_keys.go
@@ -12,7 +12,7 @@ import (
 
 func (jh *GenericHandler) GetKeys(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/handler.go
+++ b/http/handlers/handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"strings"
 
 	"github.com/srimaln91/etcd-adminer/config"
 	"github.com/srimaln91/etcd-adminer/etcd"
@@ -86,8 +85,4 @@ func (jh *GenericHandler) getKeys(ctx context.Context, endpoints []string, user,
 	}
 
 	return keys, nil
-}
-
-func parseEndpoints(header string) []string {
-	return strings.Split(header, ",")
 }

--- a/http/handlers/handler.go
+++ b/http/handlers/handler.go
@@ -42,6 +42,8 @@ func (jh *GenericHandler) getKeys(ctx context.Context, endpoints []string, user,
 		return nil, err
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	var keys *clientv3.GetResponse
 	if client.Username == "root" {
 		keys, err = client.Get(ctx, "/", clientv3.WithKeysOnly(), clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
@@ -90,4 +92,11 @@ func (jh *GenericHandler) getKeys(ctx context.Context, endpoints []string, user,
 
 func parseEndpoints(header string) []string {
 	return strings.Split(header, ",")
+}
+
+func (jh *GenericHandler) closeEtcdClient(client *etcd.Client) {
+	err := client.Close()
+	if err != nil {
+		jh.logger.Error(context.TODO(), err.Error())
+	}
 }

--- a/http/handlers/handler.go
+++ b/http/handlers/handler.go
@@ -9,6 +9,10 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+type MetaKey string
+
+const META_KEY MetaKey = "meta"
+
 type GenericHandler struct {
 	logger           log.Logger
 	superAdminClient *etcd.Client

--- a/http/handlers/roles.go
+++ b/http/handlers/roles.go
@@ -5,17 +5,19 @@ import (
 	"net/http"
 
 	"github.com/srimaln91/etcd-adminer/etcd"
+	"github.com/srimaln91/etcd-adminer/http/request"
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 )
 
 func (jh *GenericHandler) GetRoles(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/roles.go
+++ b/http/handlers/roles.go
@@ -11,7 +11,7 @@ import (
 
 func (jh *GenericHandler) GetRoles(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/roles.go
+++ b/http/handlers/roles.go
@@ -26,6 +26,8 @@ func (jh *GenericHandler) GetRoles(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	roleList, err := client.RoleList(r.Context())
 	if err != nil {
 		if err == rpctypes.ErrPermissionDenied || err == rpctypes.ErrPermissionNotGranted {

--- a/http/handlers/update_key.go
+++ b/http/handlers/update_key.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (jh *GenericHandler) UpdateKey(rw http.ResponseWriter, r *http.Request) {
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/update_key.go
+++ b/http/handlers/update_key.go
@@ -11,12 +11,13 @@ import (
 )
 
 func (jh *GenericHandler) UpdateKey(rw http.ResponseWriter, r *http.Request) {
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/update_key.go
+++ b/http/handlers/update_key.go
@@ -27,6 +27,8 @@ func (jh *GenericHandler) UpdateKey(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	reqDataDecoded := request.CreateKeyRequest{}
 	decoder := json.NewDecoder(r.Body)
 

--- a/http/handlers/users.go
+++ b/http/handlers/users.go
@@ -13,7 +13,7 @@ import (
 
 func (jh *GenericHandler) GetUserList(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
@@ -55,7 +55,7 @@ func (jh *GenericHandler) GetUserList(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
@@ -103,7 +103,7 @@ func (jh *GenericHandler) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) AssignRole(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
@@ -148,7 +148,7 @@ func (jh *GenericHandler) AssignRole(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) UnassignRole(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
@@ -193,7 +193,7 @@ func (jh *GenericHandler) UnassignRole(rw http.ResponseWriter, r *http.Request) 
 
 func (jh *GenericHandler) DeleteUser(rw http.ResponseWriter, r *http.Request) {
 
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
@@ -232,7 +232,7 @@ func (jh *GenericHandler) DeleteUser(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (jh *GenericHandler) CreateUser(rw http.ResponseWriter, r *http.Request) {
-	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	requestMeta, ok := r.Context().Value(META_KEY).(request.RequestMeta)
 	if !ok {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return

--- a/http/handlers/users.go
+++ b/http/handlers/users.go
@@ -13,12 +13,13 @@ import (
 
 func (jh *GenericHandler) GetUserList(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -54,10 +55,12 @@ func (jh *GenericHandler) GetUserList(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
 	vars := mux.Vars(r)
 
 	if _, ok := vars["name"]; !ok {
@@ -65,7 +68,7 @@ func (jh *GenericHandler) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -100,10 +103,11 @@ func (jh *GenericHandler) GetUserInfo(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) AssignRole(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
-
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	vars := mux.Vars(r)
 
@@ -117,7 +121,7 @@ func (jh *GenericHandler) AssignRole(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -144,10 +148,11 @@ func (jh *GenericHandler) AssignRole(rw http.ResponseWriter, r *http.Request) {
 
 func (jh *GenericHandler) UnassignRole(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
-
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	vars := mux.Vars(r)
 
@@ -161,7 +166,7 @@ func (jh *GenericHandler) UnassignRole(rw http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -188,10 +193,11 @@ func (jh *GenericHandler) UnassignRole(rw http.ResponseWriter, r *http.Request) 
 
 func (jh *GenericHandler) DeleteUser(rw http.ResponseWriter, r *http.Request) {
 
-	user, pass, _ := r.BasicAuth()
-
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	vars := mux.Vars(r)
 
@@ -200,7 +206,7 @@ func (jh *GenericHandler) DeleteUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)
@@ -226,12 +232,13 @@ func (jh *GenericHandler) DeleteUser(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (jh *GenericHandler) CreateUser(rw http.ResponseWriter, r *http.Request) {
-	user, pass, _ := r.BasicAuth()
+	requestMeta, ok := r.Context().Value("meta").(request.RequestMeta)
+	if !ok {
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
-	endpointString := r.Header.Get("X-Endpoints")
-	endpoints := parseEndpoints(endpointString)
-
-	client, err := etcd.NewClient(endpoints, etcd.WithAuth(user, pass))
+	client, err := etcd.NewClient(requestMeta.Endpoints, etcd.WithAuth(requestMeta.User, requestMeta.Pass))
 	if err != nil {
 		if err == rpctypes.ErrAuthFailed {
 			rw.WriteHeader(http.StatusForbidden)

--- a/http/handlers/users.go
+++ b/http/handlers/users.go
@@ -242,6 +242,8 @@ func (jh *GenericHandler) CreateUser(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	defer jh.closeEtcdClient(client)
+
 	reqDataDecoded := request.CreateUserRequest{}
 	decoder := json.NewDecoder(r.Body)
 

--- a/http/middlewares/validate.go
+++ b/http/middlewares/validate.go
@@ -1,0 +1,64 @@
+package middlewares
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/srimaln91/etcd-adminer/http/request"
+)
+
+type requestValidateMiddleware struct{}
+
+var ErrCredentialsNotProvided = errors.New("credentials are not provided")
+var ErrEndpointsNotProvided = errors.New("endpoints are not provided")
+var ErrAddressNotParseable = errors.New("can not parse ETCD endpoint address")
+
+func NewRequestValidateMiddleware() *requestValidateMiddleware {
+	return new(requestValidateMiddleware)
+}
+
+func parseEndpoints(header string) ([]string, error) {
+	addresses := strings.Split(header, ",")
+	
+	return addresses, nil
+}
+
+func getRequestMeta(r *http.Request) (meta request.RequestMeta, err error) {
+	user, pass, ok := r.BasicAuth()
+	if !ok {
+		return meta, errors.New("credentials are not provided")
+	}
+
+	meta.User = user
+	meta.Pass = pass
+
+	endpointString := r.Header.Get("X-Endpoints")
+	if endpointString == "" {
+		return meta, errors.New("endpoints are not provided")
+	}
+
+	meta.Endpoints, err = parseEndpoints(endpointString)
+	if err != nil {
+		return meta, nil
+	}
+
+	return meta, err
+}
+
+func (rvm *requestValidateMiddleware) ValidateRequest(next http.HandlerFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta, err := getRequestMeta(r)
+		if err != nil {
+			w.WriteHeader(http.StatusNotAcceptable)
+			return
+		}
+
+		// Attach request metadata to the Http request. So handlers can take it from the context
+		modifiedReq := r.WithContext(context.WithValue(r.Context(), "meta", meta))
+
+		// Call the next handler
+		next.ServeHTTP(w, modifiedReq)
+	})
+}

--- a/http/middlewares/validate.go
+++ b/http/middlewares/validate.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/srimaln91/etcd-adminer/http/handlers"
 	"github.com/srimaln91/etcd-adminer/http/request"
 )
 
@@ -21,7 +22,7 @@ func NewRequestValidateMiddleware() *requestValidateMiddleware {
 
 func parseEndpoints(header string) ([]string, error) {
 	addresses := strings.Split(header, ",")
-	
+
 	return addresses, nil
 }
 
@@ -56,7 +57,7 @@ func (rvm *requestValidateMiddleware) ValidateRequest(next http.HandlerFunc) htt
 		}
 
 		// Attach request metadata to the Http request. So handlers can take it from the context
-		modifiedReq := r.WithContext(context.WithValue(r.Context(), "meta", meta))
+		modifiedReq := r.WithContext(context.WithValue(r.Context(), handlers.META_KEY, meta))
 
 		// Call the next handler
 		next.ServeHTTP(w, modifiedReq)

--- a/http/request/meta.go
+++ b/http/request/meta.go
@@ -1,0 +1,7 @@
+package request
+
+type RequestMeta struct {
+	User      string
+	Pass      string
+	Endpoints []string
+}

--- a/http/router/router.go
+++ b/http/router/router.go
@@ -6,39 +6,42 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/srimaln91/etcd-adminer/http/handlers"
+	"github.com/srimaln91/etcd-adminer/http/middlewares"
 	"github.com/srimaln91/etcd-adminer/log"
 )
 
 func NewRouter(logger log.Logger) (http.Handler, error) {
 
 	// Init handler
-	jobRequestHandler, err := handlers.NewHTTPHandler(logger)
+	requestHandler, err := handlers.NewHTTPHandler(logger)
 	if err != nil {
 		logger.Fatal(context.Background(), err.Error())
 	}
 
+	validator := middlewares.NewRequestValidateMiddleware()
+
 	r := mux.NewRouter()
 	r.Use(CORS)
 
-	r.HandleFunc("/api/getconfig", jobRequestHandler.GetConfig).Methods(http.MethodGet, http.MethodOptions)
-	r.HandleFunc("/api/auth", jobRequestHandler.Authenticate).Methods(http.MethodPost, http.MethodOptions)
+	r.HandleFunc("/api/getconfig", requestHandler.GetConfig).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/api/auth", requestHandler.Authenticate).Methods(http.MethodPost, http.MethodOptions)
 
-	r.Handle("/api/keys", authenticate(jobRequestHandler.GetKey)).Methods(http.MethodGet, http.MethodOptions).Queries("key", "")
-	r.Handle("/api/keys", authenticate(jobRequestHandler.GetKeys)).Methods(http.MethodGet, http.MethodOptions)
-	r.Handle("/api/keys", authenticate(jobRequestHandler.UpdateKey)).Methods(http.MethodPut, http.MethodOptions)
-	r.Handle("/api/keys", authenticate(jobRequestHandler.DeleteKey)).Methods(http.MethodDelete, http.MethodOptions)
+	r.Handle("/api/keys", validator.ValidateRequest(requestHandler.GetKey)).Methods(http.MethodGet, http.MethodOptions).Queries("key", "")
+	r.Handle("/api/keys", validator.ValidateRequest(requestHandler.GetKeys)).Methods(http.MethodGet, http.MethodOptions)
+	r.Handle("/api/keys", validator.ValidateRequest(requestHandler.UpdateKey)).Methods(http.MethodPut, http.MethodOptions)
+	r.Handle("/api/keys", validator.ValidateRequest(requestHandler.DeleteKey)).Methods(http.MethodDelete, http.MethodOptions)
 
-	r.Handle("/api/directory", authenticate(jobRequestHandler.CreateDirectory)).Methods(http.MethodPost, http.MethodOptions)
-	r.Handle("/api/clusterinfo", authenticate(jobRequestHandler.ClusterInfo)).Methods(http.MethodGet, http.MethodOptions)
+	r.Handle("/api/directory", validator.ValidateRequest(requestHandler.CreateDirectory)).Methods(http.MethodPost, http.MethodOptions)
+	r.Handle("/api/clusterinfo", validator.ValidateRequest(requestHandler.ClusterInfo)).Methods(http.MethodGet, http.MethodOptions)
 
-	r.Handle("/api/users", authenticate(jobRequestHandler.GetUserList)).Methods(http.MethodGet, http.MethodOptions)
-	r.Handle("/api/users", authenticate(jobRequestHandler.CreateUser)).Methods(http.MethodPost, http.MethodOptions)
-	r.Handle("/api/users/{name}", authenticate(jobRequestHandler.GetUserInfo)).Methods(http.MethodGet, http.MethodOptions)
-	r.Handle("/api/users/{name}", authenticate(jobRequestHandler.DeleteUser)).Methods(http.MethodDelete, http.MethodOptions)
-	r.Handle("/api/users/{name}/role/{role}", authenticate(jobRequestHandler.AssignRole)).Methods(http.MethodPost, http.MethodOptions)
-	r.Handle("/api/users/{name}/role/{role}", authenticate(jobRequestHandler.UnassignRole)).Methods(http.MethodDelete, http.MethodOptions)
+	r.Handle("/api/users", validator.ValidateRequest(requestHandler.GetUserList)).Methods(http.MethodGet, http.MethodOptions)
+	r.Handle("/api/users", validator.ValidateRequest(requestHandler.CreateUser)).Methods(http.MethodPost, http.MethodOptions)
+	r.Handle("/api/users/{name}", validator.ValidateRequest(requestHandler.GetUserInfo)).Methods(http.MethodGet, http.MethodOptions)
+	r.Handle("/api/users/{name}", validator.ValidateRequest(requestHandler.DeleteUser)).Methods(http.MethodDelete, http.MethodOptions)
+	r.Handle("/api/users/{name}/role/{role}", validator.ValidateRequest(requestHandler.AssignRole)).Methods(http.MethodPost, http.MethodOptions)
+	r.Handle("/api/users/{name}/role/{role}", validator.ValidateRequest(requestHandler.UnassignRole)).Methods(http.MethodDelete, http.MethodOptions)
 
-	r.Handle("/api/role", authenticate(jobRequestHandler.GetRoles)).Methods(http.MethodGet, http.MethodOptions)
+	r.Handle("/api/role", validator.ValidateRequest(requestHandler.GetRoles)).Methods(http.MethodGet, http.MethodOptions)
 
 	spa := spaHandler{staticPath: "static", indexPath: "index.html"}
 	r.PathPrefix("/").Handler(spa)
@@ -60,32 +63,6 @@ func CORS(next http.Handler) http.Handler {
 		}
 
 		// Next
-		next.ServeHTTP(w, r)
-	})
-}
-
-func authenticate(next http.HandlerFunc) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check HTTP authorization header
-		_, _, ok := r.BasicAuth()
-		if !ok {
-			w.WriteHeader(http.StatusForbidden)
-			return
-		}
-
-		// Check whether the endpoints are provided
-		endpointString := r.Header.Get("X-Endpoints")
-		if endpointString == "" {
-			w.WriteHeader(http.StatusNotAcceptable)
-			return
-		}
-
-		if len(endpointString) < 1 {
-			w.WriteHeader(http.StatusNotAcceptable)
-			return
-		}
-
-		// Call the next handler
 		next.ServeHTTP(w, r)
 	})
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -49,7 +48,6 @@ func NewLogger(level Level) (Logger, error) {
 	}
 
 	lev := zapcore.Level(logLevel)
-	fmt.Println(lev.String())
 	cfg := zap.Config{
 		Level:         zap.NewAtomicLevelAt(lev),
 		Encoding:      "json",


### PR DESCRIPTION
- close client connections on each and every operation
- use an HTTP middleware to parse and forward request metadata
- avoid printing log level in stdout