### PR TITLE
Sync README.md's config sample block with config.default.yaml.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![image info](./resources/screenshot.png)
 
 ## Configuration
-The application config is defined in yaml format.
+The application config is defined in yaml format.  You may obtain it from (config.default.yaml)[config.default.yaml].
 
 ```yaml
 http:
@@ -14,6 +14,7 @@ logger:
   level: "DEBUG"
 
 etcd:
+- name: "LOCAL"
   endpoints:
     - "0.0.0.0:23791"
     - "0.0.0.0:23792"


### PR DESCRIPTION
This should fix https://github.com/srimaln91/etcd-adminer/issues/24 since it's caused from missing `name` entry in `README.md`.

Also add a hint to gudie people checking `config.default.yaml`.